### PR TITLE
Criação de ControllerPredict com endpoint POST '/predict', e mock par…

### DIFF
--- a/api-java/continuum/src/main/java/com/hackathon/continuum/controller/ControllerPredict.java
+++ b/api-java/continuum/src/main/java/com/hackathon/continuum/controller/ControllerPredict.java
@@ -1,0 +1,24 @@
+package com.hackathon.continuum.controller;
+
+import com.hackathon.continuum.dto.EntradaDTO;
+import com.hackathon.continuum.dto.RespostaDTO;
+import com.hackathon.continuum.service.PredictService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/predict")
+public class ControllerPredict {
+
+    @Autowired
+    PredictService predict;
+
+    @PostMapping
+    public ResponseEntity<RespostaDTO> predict(@RequestBody  EntradaDTO entradaDTO){
+            RespostaDTO respostaDTO = predict.predict(entradaDTO);
+
+            return ResponseEntity.ok(respostaDTO);
+
+    }
+}

--- a/api-java/continuum/src/main/java/com/hackathon/continuum/service/PredictService.java
+++ b/api-java/continuum/src/main/java/com/hackathon/continuum/service/PredictService.java
@@ -1,0 +1,22 @@
+package com.hackathon.continuum.service;
+
+import com.hackathon.continuum.dto.EntradaDTO;
+import com.hackathon.continuum.dto.RespostaDTO;
+import org.springframework.stereotype.Service;
+
+@Service
+public class PredictService {
+
+    //TODO: implementar serviço de comunicação para API de dados
+    //Observação: Atualmente é um mock.
+    public RespostaDTO predict(EntradaDTO entradaDTO){
+        return mockPredict();
+    }
+
+
+    //TODO: remover após conclusão do serviço.
+    public RespostaDTO mockPredict(){
+        return new RespostaDTO("Vai cancelar", 0.76);
+    }
+
+}


### PR DESCRIPTION
…a serviço do serviço de análise.

Criação de controller Predict para endpoint POST '/predict', que retornará um JSON contendo a predição para um cliente.

Criação de mock para PredictService, que tem como objetivo final servir de interface para o módulo de dados e fornecer a predição.